### PR TITLE
fixes for homepage title, use osmgeoweek.org instead of osmgeoweek.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .DS_Store
 /_site
 *~
+
+# keep personal configuration out of the repo
+# (although agreeing on a .ruby-version, .ruby-gemset, and Gemfile might not be a bad idea)
+.idea/
+.ruby-*
+Gemfile*
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
   <meta name='twitter:site' content='@osmgeoweek' />
   <meta property='og:site_name' content='OpenStreetMap - Geography Awareness Week' />
   <meta name='twitter:url' content='{{page.permalink}}' />
-  <meta name='twitter:domain' content='http://osmgeoweek.com' />
+  <meta name='twitter:domain' content='http://osmgeoweek.org' />
   <meta property='og:url' content='{{page.permalink}}' />
   <meta name='twitter:title' content='{{page.title | replace:"'","&lsquo;"}}' />
   <meta property='og:title' content='{{page.title | replace:"'","&lsquo;"}}' />
@@ -21,9 +21,9 @@
     <meta name='st:image' content='{{page.image | replace:"https:","http:"}}' />
     <meta property='og:image' content='{{page.image | replace:"https:","http:"}}' />
   {% else %}
-    <meta name='twitter:image' content='http://osmgeoweek.com/img/default-twitter-card.png' />
-    <meta name='st:image' content='http://osmgeoweek.com/img/default-twitter-card.png' />
-    <meta property='og:image' content='http://osmgeoweek.com/img/default-twitter-card.png' />
+    <meta name='twitter:image' content='http://osmgeoweek.org/img/default-twitter-card.png' />
+    <meta name='st:image' content='http://osmgeoweek.org/img/default-twitter-card.png' />
+    <meta property='og:image' content='http://osmgeoweek.org/img/default-twitter-card.png' />
   {% endif %}
   <meta property='og:type' content='website' />
   <meta name='twitter:card' content='summary_large_image' />
@@ -86,7 +86,7 @@
   <div class='fill-darken3 pad2y col12'>
     <div class='limiter'>
       <p class='small hide-mobile'>
-        <a href='http://osmgeoweek.com'>Geography Awareness Week - OpenStreetMap</a> | <a href='https://twitter.com/search?q=%23osmgeoweek&src=typd'>#osmgeoweek</a> | Photo credits: USAID, 596 acres, UCSB, Kerri Lee Smith
+        <a href='http://osmgeoweek.org'>Geography Awareness Week - OpenStreetMap</a> | <a href='https://twitter.com/search?q=%23osmgeoweek&src=typd'>#osmgeoweek</a> | Photo credits: USAID, 596 acres, UCSB, Kerri Lee Smith
 <!-- https://www.flickr.com/photos/usaid_images/11712673254/ -->
 <!-- http://596acres.org/en/ -->
 <!-- http://helios.geog.ucsb.edu/events/department-news/963/ucsb-geography-promotes-the-adventure-in-your-community-for-geography-awareness-week/ -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
   <meta property='og:type' content='website' />
   <meta name='twitter:card' content='summary_large_image' />
 
-  <title>{% if page.url == "/index.html"  %}{% else %}{{page.title}} | {% endif %}OpenStreetMap Geography Awareness Week</title>
+  <title>{% if page.url == "/"  %}{% else %}{{page.title}} | {% endif %}OpenStreetMap Geography Awareness Week</title>
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel='shortcut icon' href='{{site.baseurl}}/img/favicon.ico' type='image/x-icon' />
   <link href='http://fonts.googleapis.com/css?family=Kreon:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
This diffs will be pretty self explanatory.
